### PR TITLE
Postgres: set min Jdbc version to 42.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>[42.2.0,)</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
to handle correctly the scram-sha-256 password for alfresco user